### PR TITLE
Ignored attempt to cancel a touchmove event

### DIFF
--- a/packages/pull-to-refresh/src/PullToRefresh.tsx
+++ b/packages/pull-to-refresh/src/PullToRefresh.tsx
@@ -214,7 +214,10 @@ export default class PullToRefresh extends React.Component<IPropsType, IState> {
 
         this.setState({ dragOnEdge: true });
       }
-      e.preventDefault();
+      
+      //https://github.com/ant-design/ant-design-mobile/issues/3184
+      if(e.cancelable)
+        e.preventDefault();
       // add stopPropagation with fastclick will trigger content onClick event. why?
       // ref https://github.com/ant-design/ant-design-mobile/issues/2141
       // e.stopPropagation();


### PR DESCRIPTION
Fixed the error that occurred while scrolling.
Error: Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.